### PR TITLE
add ability to return an object with lazy variations of the desired functions / props

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -1,4 +1,0 @@
-'use strict';
-module.exports = function () {
-	return 'foo';
-};

--- a/fixtures/foo.bar.js
+++ b/fixtures/foo.bar.js
@@ -1,0 +1,8 @@
+'use strict';
+module.exports.foo = function () {
+	return 'foo';
+};
+module.exports.bar = function () {
+	return 'bar';
+};
+module.exports.baz = 'baz';

--- a/fixtures/foo.bar.js
+++ b/fixtures/foo.bar.js
@@ -1,8 +1,11 @@
 'use strict';
+
 module.exports.foo = function () {
 	return 'foo';
 };
-module.exports.bar = function () {
-	return 'bar';
+
+module.exports.bar = function (ho, ge) {
+	return 'bar' + ho + ge;
 };
+
 module.exports.baz = 'baz';

--- a/fixtures/foo.js
+++ b/fixtures/foo.js
@@ -1,0 +1,4 @@
+'use strict';
+module.exports = function () {
+	return 'foo';
+};

--- a/index.js
+++ b/index.js
@@ -1,9 +1,28 @@
 'use strict';
+var slice = Array.prototype.slice
 module.exports = function (fn) {
-	return function (id) {
-		var mod;
+	return function (id, mod) {
 		return function () {
-			return mod !== undefined ? mod : mod = fn(id);
+			if (!arguments.length) return mod = lazy(mod, fn, id);
+			var obj = {}, args = slice.call(arguments, 0);
+			args.forEach(function (prop) {
+				Object.defineProperty(obj, prop, {
+					get: function () {
+						mod = lazy(mod, fn, id);
+						if (typeof mod[prop] === 'function') {
+							return function () {
+								return mod[prop].apply(mod, slice.call(arguments, 0));
+							}
+						} else {
+							return mod[prop];
+						}
+					}
+				});
+			});
+			return obj;
 		};
 	};
+	function lazy (mod, fn, id) {
+		return mod !== undefined ? mod : fn(id);
+	}
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     "email": "sindresorhus@gmail.com",
     "url": "http://sindresorhus.com"
   },
+  "contributors": [
+    {
+      "name": "Jorge Bucaran",
+      "email": "jbucaran@me.com"
+    }
+  ],
   "engines": {
     "node": ">=0.10.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,18 @@ _().isNumber(2);
 
 // it's cached on consecutive calls
 _().isString('unicorn');
-```
 
+// extract lazy variations of the props you need
+var members = lazyReq('lodash')('isNumber', 'isString')
+
+// useful when using destructuring assignment in ES6
+let { isNumber, isString } = lazyReq('lodash')('isNumber', 'isString')
+
+// works out of the box for functions and regular properties
+var stuff = lazyReq('./math-lib')('sum', 'PHI')
+console.log(stuff.sum(1, 2)) // => 3
+console.log(stuff.PHI) // => 1.618033
+```
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -1,9 +1,18 @@
 'use strict';
+
 var test = require('ava');
 var lazyReq = require('./')(require);
 
 test(function (t) {
-	var f = lazyReq('./fixture');
+	var f = lazyReq('./fixtures/foo');
 	t.assert(f() === f());
 	t.assert(f()() === 'foo');
+});
+
+test(function (t) {
+	var obj = lazyReq('./fixtures/foo.bar.js')('foo', 'bar', 'baz');
+	t.assert(obj.foo() === 'foo');
+	t.assert(obj.foo() === 'foo');
+	t.assert(obj.bar('j', 's') === 'barjs');
+	t.assert(obj.baz === 'baz');
 });


### PR DESCRIPTION
Hey!

I thought this module could be even more useful if we had the ability to return an object with the lazy versions of the props one needs. Useful when using ES6 with the destructuring assignment and still get the lazy versions of the needed props.

```js
// extract lazy variations of the props you need
var members = lazyReq('lodash')('isNumber', 'isString')

// useful when using destructuring assignment in ES6
let { isNumber, isString } = lazyReq('lodash')('isNumber', 'isString')
```

The only minor caveat is that for property members a function stub that _returns the value_ will be returned. I think most people using this feature will probably want to extract a function anyway.

This could be mitigated to some extent using an object to specify the Type of the property to extract instead of just passing arguments:

```js
let { isNumber, isString } = lazyReq('foo')({
  function: "baz",
  property: "bar",
  ...
})
```

I also noticed there could be other lazy loading strategies. I simply went with the simplest one I could imagine, but certainly a more sophisticated algorithm could be imagine.

Let me know if there is anything weird with the PR or whether you want to add more tests.