### PR TITLE
Add support for ES2015 proxies

### DIFF
--- a/fixtures/baz.js
+++ b/fixtures/baz.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = (ho, ge) => `baz${ho}${ge}`;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
-module.exports = fn => {
-	const lazy = (mod, fn, id) => mod === undefined ? fn(id) : mod;
+const lazy = (mod, fn, id) => mod === undefined ? fn(id) : mod;
 
+module.exports = fn => {
 	return id => {
 		let mod;
 
@@ -30,5 +30,24 @@ module.exports = fn => {
 
 			return ret;
 		};
+	};
+};
+
+module.exports.proxy = fn => {
+	return id => {
+		let mod;
+
+		const handler = {
+			get: (target, property) => {
+				mod = lazy(mod, fn, id);
+				return Reflect.get(mod, property);
+			},
+			apply: (target, thisArg, argumentsList) => {
+				mod = lazy(mod, fn, id);
+				return Reflect.apply(mod, thisArg, argumentsList);
+			}
+		};
+
+		return new Proxy(() => {}, handler);
 	};
 };

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,17 @@ console.log(stuff.sum(1, 2)); // => 3
 console.log(stuff.PHI); // => 1.618033
 ```
 
+### Proxy support in Node.js 6 or later
+
+If you use Node.js 6 or later, you can take advantage of ES2015 proxies and don't need to call it as a function.
+
+```js
+const lazyReq = require('lazy-req').proxy(require);
+const _ = lazyReq('lodash');
+
+// No need to call it as a function but still lazily required
+_.isNumber(2);
+```
 
 ## Related
 

--- a/test-proxy.js
+++ b/test-proxy.js
@@ -1,0 +1,24 @@
+import test from 'ava';
+import m from './';
+
+const testSkipNode4 = /^v4/.test(process.version) ? test.skip : test;
+const lazyReq = m.proxy(require);
+
+testSkipNode4('main', t => {
+	const f = lazyReq('./fixtures/foo');
+	t.is(f(), 'foo');
+
+	const g = lazyReq('./fixtures/baz');
+	t.is(g('j', 's'), 'bazjs');
+});
+
+testSkipNode4('lazy', () => {
+	lazyReq('./fixtures/fail');
+});
+
+testSkipNode4('props', t => {
+	const obj = lazyReq('./fixtures/foo.bar.js');
+	t.is(obj.foo(), 'foo');
+	t.is(obj.bar('j', 's'), 'barjs');
+	t.is(obj.baz, 'baz');
+});


### PR DESCRIPTION
Adds support for [ES2015 proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) so you no longer need to call it as a function. Closes #3.

In case you are wondering why I have added the `baz` fixture instead of using `obj.bar()`: I needed a way to test if function arguments are correctly proxied when the module directly exports a function. In this case, the `apply` trap gets called whereas when using `obj.bar()` the `get` trap gets called.